### PR TITLE
Update Color Tokens from Figma (20250729_200720)

### DIFF
--- a/Color.xcassets/Contents.json
+++ b/Color.xcassets/Contents.json
@@ -1,6 +1,2 @@
-{
-  "info": {
-    "version": 1,
-    "author": "xcode"
-  }
-}
+ewogICJpbmZvIjogewogICAgInZlcnNpb24iOiAxLAogICAgImF1dGhvciI6
+ICJ4Y29kZSIKICB9Cn0=

--- a/Color.xcassets/Gray/200.colorset/Contents.json
+++ b/Color.xcassets/Gray/200.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0xE9",
+          "green": "0xE9",
+          "blue": "0xE9",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Gray/400.colorset/Contents.json
+++ b/Color.xcassets/Gray/400.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0xCC",
+          "green": "0xCC",
+          "blue": "0xCC",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Gray/600.colorset/Contents.json
+++ b/Color.xcassets/Gray/600.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0x63",
+          "green": "0x63",
+          "blue": "0x63",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Gray/800.colorset/Contents.json
+++ b/Color.xcassets/Gray/800.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0x3B",
+          "green": "0x3B",
+          "blue": "0x3B",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Gray/Contents.json
+++ b/Color.xcassets/Gray/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Point/Contents.json
+++ b/Color.xcassets/Point/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Point/Primary.colorset/Contents.json
+++ b/Color.xcassets/Point/Primary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0xA9",
+          "green": "0xBD",
+          "blue": "0xFF",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Point/Secondary.colorset/Contents.json
+++ b/Color.xcassets/Point/Secondary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0x84",
+          "green": "0x79",
+          "blue": "0xFF",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Point/Sub1.colorset/Contents.json
+++ b/Color.xcassets/Point/Sub1.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0x81",
+          "green": "0xB9",
+          "blue": "0xFF",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Point/Sub2.colorset/Contents.json
+++ b/Color.xcassets/Point/Sub2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0xA8",
+          "green": "0xCF",
+          "blue": "0xFF",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Point/Sub3.colorset/Contents.json
+++ b/Color.xcassets/Point/Sub3.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0xD6",
+          "green": "0xE8",
+          "blue": "0xFF",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Point/Sub4.colorset/Contents.json
+++ b/Color.xcassets/Point/Sub4.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0xF0",
+          "green": "0xF2",
+          "blue": "0xFA",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 다양한 회색(Gray) 및 포인트(Point) 계열의 색상 자산이 추가되었습니다.  
  * 각 색상은 sRGB 색상 공간과 완전 불투명(alpha 1.0)으로 정의되어 있습니다.

* **기타**
  * 기존 색상 자산의 내부 형식이 base64 인코딩 방식으로 변경되었습니다.  
  * 색상 자산 메타데이터 파일이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->