### PR TITLE
Update Color Tokens from Figma (20250729_203308)

### DIFF
--- a/Color.xcassets/Gray/200.colorset/Contents.json
+++ b/Color.xcassets/Gray/200.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0xE9",
+          "green": "0xE9",
+          "blue": "0xE9",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Gray/400.colorset/Contents.json
+++ b/Color.xcassets/Gray/400.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0xCC",
+          "green": "0xCC",
+          "blue": "0xCC",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Gray/600.colorset/Contents.json
+++ b/Color.xcassets/Gray/600.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0x63",
+          "green": "0x63",
+          "blue": "0x63",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Gray/800.colorset/Contents.json
+++ b/Color.xcassets/Gray/800.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0x3B",
+          "green": "0x3B",
+          "blue": "0x3B",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Gray/Contents.json
+++ b/Color.xcassets/Gray/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Point/Contents.json
+++ b/Color.xcassets/Point/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Point/Primary.colorset/Contents.json
+++ b/Color.xcassets/Point/Primary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0xA9",
+          "green": "0xBD",
+          "blue": "0xFF",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Point/Secondary.colorset/Contents.json
+++ b/Color.xcassets/Point/Secondary.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0x84",
+          "green": "0x79",
+          "blue": "0xFF",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Point/Sub1.colorset/Contents.json
+++ b/Color.xcassets/Point/Sub1.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0x81",
+          "green": "0xB9",
+          "blue": "0xFF",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Point/Sub2.colorset/Contents.json
+++ b/Color.xcassets/Point/Sub2.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0xA8",
+          "green": "0xCF",
+          "blue": "0xFF",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Point/Sub3.colorset/Contents.json
+++ b/Color.xcassets/Point/Sub3.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0xD6",
+          "green": "0xE8",
+          "blue": "0xFF",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}

--- a/Color.xcassets/Point/Sub4.colorset/Contents.json
+++ b/Color.xcassets/Point/Sub4.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors": [
+    {
+      "idiom": "universal",
+      "color": {
+        "color-space": "srgb",
+        "components": {
+          "red": "0xF0",
+          "green": "0xF2",
+          "blue": "0xFA",
+          "alpha": "1.000"
+        }
+      }
+    }
+  ],
+  "info": {
+    "version": 1,
+    "author": "xcode"
+  }
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 다양한 회색(Gray 200, 400, 600, 800) 및 포인트(Primary, Secondary, Sub1~Sub4) 색상 자산이 추가되었습니다.
  * 색상 자산 관리 및 구성을 위한 관련 메타데이터 파일이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->